### PR TITLE
Update Django Pyas2 link

### DIFF
--- a/deployment/use-as2.rst
+++ b/deployment/use-as2.rst
@@ -22,7 +22,7 @@ Several threads in the mailing list about this:
 
 * http://sourceforge.net/projects/mec-as2/
 * http://sourceforge.net/projects/openas2/
-* https://github.com/abhishek-ram/pyas2
+* https://github.com/abhishek-ram/django-pyas2
 * http://www.cecid.hku.hk/hermes.php
 * http://stackoverflow.com/questions/7426951/is-anyone-using-python-for-gs1-xml-and-as2-edi
 


### PR DESCRIPTION
The project that was linked has been abandoned as it moved to the new name.