### PR TITLE
Last changes to v.3.2.0 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 # Bots-EDI Documentation
 
-This is the source of documentation published on: [http://bots.readthedocs.io](http://bots.readthedocs.io)
+This is the source of documentation published on: [http://bots.readthedocs.io](http://bots.readthedocs.io).
 
-Bots is an Open Source EDI translator. Source code: [github.com/eppye-bots/bots](https://github.com/eppye-bots/bots). Bots sourceforge web site: http://bots.sourceforge.net. Commercial support by EbberConsult, [http://www.ebbersconsult.com](http://www.ebbersconsult.com)
+Bots is an Open Source EDI translator. Source code: [github.com/eppye-bots/bots](https://github.com/eppye-bots/bots). Bots web site: [bots-edi.org](https://bots-edi.org). 
 
 Bots is licenced under GNU GENERAL PUBLIC LICENSE Version 3; for full text: http://www.gnu.org/copyleft/gpl.html

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![bots_logo](images/botslogo_chain.png)
 
-# Bots-EDI Documentation
+# Bots v3.2.0 (Frozen) Documentation
 
 This is the source of documentation published on: [http://bots.readthedocs.io](http://bots.readthedocs.io).
 

--- a/conf.py
+++ b/conf.py
@@ -290,4 +290,7 @@ texinfo_documents = [
 # Edit on GitHub link
 html_context = {
   'display_github': True,
+  'github_user': 'eppye-bots',
+  'github_repo': 'wiki_for_rtd',
+  'github_version': 'master/',
 }

--- a/conf.py
+++ b/conf.py
@@ -290,7 +290,4 @@ texinfo_documents = [
 # Edit on GitHub link
 html_context = {
   'display_github': True,
-  'github_user': 'eppye-bots',
-  'github_repo': 'wiki_for_rtd',
-  'github_version': 'master/',
 }

--- a/configuration/channel/channel-scripting.rst
+++ b/configuration/channel/channel-scripting.rst
@@ -19,7 +19,7 @@ Instruction to make a channel script:
 
 #. Small user exits: at certain places in normal communication a user script is called. Examples of `small user exits <#small-user-exits>`_
 #. Subclass: take-over of (parts of) communication script: user script subclasses existing communication type.
-#. Communication type ``communicationscript``. Bots tries to do the bots-handling of files, you provide the communication details. Examples of `communication type 'communicationscript' <communication-type-communicationscript>`_
+#. Communication type ``communicationscript``. Bots tries to do the bots-handling of files, you provide the communication details. Examples of `communication type 'communicationscript' <#communication-type-script>`_
 
 Small User Exits
 ----------------
@@ -284,6 +284,8 @@ In this case communication-type of the channel is 'ftp'. The class 'ftp' subclas
             except:
                 self.session.close()
             botslib.settimeout(botsglobal.ini.getint('settings','globaltimeout',10))
+
+.. _communication-type-script:
 
 Communication type ``communicationscript``
 ------------------------------------------

--- a/welcome.rst
+++ b/welcome.rst
@@ -2,7 +2,8 @@ Welcome to Bots
 ===============
 
 .. note::
-   The most recent PDF version of this document is available at `bots.readthedocs.io <https://bots.readthedocs.io/_/downloads/en/latest/pdf/>`_.
+   * This is the documentation of Bots-EDI v3.2.0 (Frozen).
+   * The most recent PDF version of this document is available at `bots.readthedocs.io <https://bots.readthedocs.io/_/downloads/en/latest/pdf/>`_.
 
 * **Bots** is fully functional software for `EDI (Electronic Data Interchange) <https://en.wikipedia.org/wiki/Electronic_data_interchange>`_. 
 * All major EDI data formats are supported: EDIFACT, X12, TRADACOMS, XML. 


### PR DESCRIPTION
Last fixes to v3.2.0 (Frozen) documentation, before leaving it as is on GitHub and moving to GitLab:
- another internal link fixed,
- update README indicating the version v3.2.0,
- update bots website address.